### PR TITLE
Update Resources.md

### DIFF
--- a/doc_source/Resources.md
+++ b/doc_source/Resources.md
@@ -28,3 +28,5 @@ The AWS Blog has a number of posts to help you use AWS services\. For example, s
 + [ AWS Global Accelerator for Availability and Performance](https://aws.amazon.com/blogs/startups/how-to-accelerate-your-wordpress-site-with-amazon-cloudfront/)
 + [ Traffic management with AWS Global Accelerator](https://aws.amazon.com/blogs/networking-and-content-delivery/traffic-management-with-aws-global-accelerator/)
 + [ Analyzing and visualizing AWS Global Accelerator flow logs using Amazon Athena and Amazon QuickSight](https://aws.amazon.com/blogs/networking-and-content-delivery/analyzing-and-visualizing-aws-global-accelerator-flow-logs-using-amazon-athena-and-amazon-quicksight/)
+
+To see a complete list of AWS Global Accelerator blogs, refer to [Networking & Content Delivery: Category: AWS Global Accelerator](https://aws.amazon.com/blogs/networking-and-content-delivery/category/networking-content-delivery/aws-global-accelerator/)


### PR DESCRIPTION
Added line #32 to point to the main blog page for all AWS Global Accelerator (GA) blogs. This make it easier for the end user to find all the blogs for AWS GA. Pointing to just three blogs posts (line #28 - #30) does not make sense.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
