### PR TITLE
Update about-endpoints-endpoint-weights.md

### DIFF
--- a/doc_source/about-endpoints-endpoint-weights.md
+++ b/doc_source/about-endpoints-endpoint-weights.md
@@ -1,6 +1,6 @@
 # Endpoint weights<a name="about-endpoints-endpoint-weights"></a>
 
-A weight is a value that determines the proportion of traffic that Global Accelerator directs to an endpoint in a standard accelerator\. Global Accelerator calculates the sum of the weights for the endpoints in an endpoint group, and then directs traffic to the endpoints based on the ratio of each endpoint's weight to the total\.
+A weight is a value that determines the proportion of traffic that Global Accelerator directs to an endpoint (Network Load Balancers, Application Load Balancers, Amazon EC2 instances, or Elastic IP addresses) in a standard accelerator\. Global Accelerator calculates the sum of the weights for the endpoints in an endpoint group, and then directs traffic to the endpoints based on the ratio of each endpoint's weight to the total\.
 
 Weighted routing lets you choose how much traffic is routed to a resource in an endpoint group\. This can be useful in several ways, including load balancing and testing new versions of an application\.
 


### PR DESCRIPTION
Called out in line#4 what the endpoints are as in case of endpoints weights, user may get confused to think that endpoint may only mean target behind an ALB or NLB (and not EC2 or EIPs)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
